### PR TITLE
Fix API timing out after 15 seconds

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ApplicationRecord
 
 	def count_hits
 		start = Time.now.beginning_of_month
-		hits = hits.where('created_at > ?', start).count
-		return hits
+		hits.where('created_at > ?', start).count
   end
 end

--- a/db/migrate/20231205121051_add_user_id_created_at_index_to_hits.rb
+++ b/db/migrate/20231205121051_add_user_id_created_at_index_to_hits.rb
@@ -1,0 +1,5 @@
+class AddUserIdCreatedAtIndexToHits < ActiveRecord::Migration[7.0]
+  def change
+    add_index :hits, [:user_id, :created_at]
+  end
+end

--- a/db/migrate/20231205121414_remove_user_id_index_from_hits.rb
+++ b/db/migrate/20231205121414_remove_user_id_index_from_hits.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdIndexFromHits < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :hits, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_05_120232) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_05_121414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,7 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_05_120232) do
     t.string "endpoint", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_hits_on_user_id"
+    t.index ["user_id", "created_at"], name: "index_hits_on_user_id_and_created_at"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
User#count_hits method's response time is around 500ms and is called 50 times per second (on average).

This PR fixes it by adding an index in the hits table in the user_id and created_at columns.

Old:

```
acme_api_development=# EXPLAIN ANALYZE SELECT COUNT(*) FROM "hits" WHERE "hits"."user_id" = 1 AND (created_at > '2023-12-01 00:00:00');
                                                             QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=12.65..12.66 rows=1 width=8) (actual time=0.020..0.020 rows=1 loops=1)
   ->  Bitmap Heap Scan on hits  (cost=4.18..12.65 rows=1 width=0) (actual time=0.013..0.013 rows=0 loops=1)
         Recheck Cond: (user_id = 1)
         Filter: (created_at > '2023-12-01 00:00:00'::timestamp without time zone)
         ->  Bitmap Index Scan on index_hits_on_user_id  (cost=0.00..4.18 rows=4 width=0) (actual time=0.011..0.011 rows=0 loops=1)
               Index Cond: (user_id = 1)
 Planning Time: 0.411 ms
 Execution Time: 0.091 ms
(8 rows)
```

New: 

```
acme_api_development=# EXPLAIN ANALYZE SELECT COUNT(*) FROM "hits" WHERE "hits"."user_id" = 1 AND (created_at > '2023-12-01 00:00:00');
                                                                      QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=8.17..8.18 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=1)
   ->  Index Only Scan using index_hits_on_user_id_and_created_at on hits  (cost=0.15..8.17 rows=1 width=0) (actual time=0.002..0.002 rows=0 loops=1)
         Index Cond: ((user_id = 1) AND (created_at > '2023-12-01 00:00:00'::timestamp without time zone))
         Heap Fetches: 0
 Planning Time: 0.243 ms
 Execution Time: 0.019 ms
(6 rows)
```

Other future possible solutions:

1) If the previous months' data is unimportant, we can delete the old hits.
2) Cache (Example: rails counters)
3) Rate Limiting Middleware. (Ex: rack-attack)