### PR TITLE
Fix count hits calculation for different timezones

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
 	has_many :hits
+  validates :timezone, inclusion: { in: ActiveSupport::TimeZone.all.map { |tz| tz.tzinfo.name } },
+    allow_blank: true
 
 	def count_hits
 		start = Time.now.beginning_of_month

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,9 @@ class User < ApplicationRecord
     allow_blank: true
 
 	def count_hits
-		start = Time.now.beginning_of_month
-		hits.where('created_at > ?', start).count
+    Time.use_zone(timezone) do
+      start = Time.zone.now.beginning_of_month
+      hits.where('created_at > ?', start).count
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,8 @@ class User < ApplicationRecord
 	def count_hits
     Time.use_zone(timezone) do
       start = Time.zone.now.beginning_of_month
-      hits.where('created_at > ?', start).count
+      end_time = Time.zone.now.end_of_month
+      hits.where(created_at: start..end_time).count
     end
   end
 end

--- a/db/migrate/20231205122540_add_timezone_to_user.rb
+++ b/db/migrate/20231205122540_add_timezone_to_user.rb
@@ -1,0 +1,5 @@
+class AddTimezoneToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :timezone, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_05_121414) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_05_122540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_05_121414) do
   create_table "users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "timezone"
   end
 
   add_foreign_key "hits", "users"


### PR DESCRIPTION
Users in Australia are complaining they still get some “over quota” errors from the API after their quota resets at the beginning of the month and after a few hours, it resolves itself.

It happens because the application's time zone is different from the user's time zone.

Ex: 

Application time zone: UTC
User time zone: Australia/Brisbane (+10)

On December 1st, 6 am (Brisbane time) the application still has November 30th, 8 pm (UTC) and the user will get an “over quota” error.

This PR fixes it by adding a `timezone` column to the user and considering it in the `user#count_hits` query.


```ruby
# Australia/Brisbane timezone
3.1.2 :001 > User.first.count_hits
  Hit Count (0.4ms)  SELECT COUNT(*) FROM "hits" WHERE "hits"."user_id" = $1 AND (created_at > '2023-11-30 14:00:00' AND created_at < '2023-12-31 13:59:59.999999')  [["user_id", 1]]
  
# Null timezone
3.1.2 :002 > User.second.count_hits
  Hit Count (0.2ms)  SELECT COUNT(*) FROM "hits" WHERE "hits"."user_id" = $1 AND (created_at > '2023-12-01 00:00:00' AND created_at < '2023-12-31 23:59:59.999999')  [["user_id", 2]]
```