### PR TITLE
Fix users being able to make API requests over the monthly limit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@ class ApplicationController < ActionController::API
 	before_filter :user_quota
 
 	def user_quota
-		render json: { error: 'over quota' } if current_user.count_hits >= 10000
+    Hit.transaction do
+      Hit.create(user: current_user, endpoint: request.path)
+      render json: { error: 'over quota' } if current_user.count_hits >= 10000
+    end
   end
 end


### PR DESCRIPTION
This issue might be created because of concurrent requests. I don't know exactly when the hit creation happens so it can also be caused by a delayed update.

This PR fixes it by making the hit creation and quota verification an atomic operation. This ensures that concurrent requests are properly accounted for and that the quota check and update happen atomically, preventing multiple requests from slipping past the limit.